### PR TITLE
Add romanization for north_atlantic_group

### DIFF
--- a/events/syncretized_culture.txt
+++ b/events/syncretized_culture.txt
@@ -600,6 +600,7 @@ province_event = {
 					OR = {
 						culture_group = gaulish_group
 						culture_group = ligures_group
+						culture_group = north_atlantic_group
 					}
 				}
 				change_culture = gallo_roman
@@ -2367,6 +2368,7 @@ province_event = {
 				OR = {
 					culture_group = gaulish_group
 					culture_group = ligures_group
+					culture_group = north_atlantic_group
 				}
 			}
 			change_culture = gallo_roman


### PR DESCRIPTION
Ensures that the Roman Syncretized event allows provinces which are of culture `north_atlantic_group` to convert to `gallo_roman`.