### PR TITLE
Fix Devotion tooltip header still labeled "Devotion" (#262)

### DIFF
--- a/localisation/replace/replace_EU4_l_english.yml
+++ b/localisation/replace/replace_EU4_l_english.yml
@@ -184,7 +184,7 @@
  HAVE_DEVOTION_LESS_THAN:0 "Have less Political Authority than "
  HAVE_DEVOTION_MORE_THAN:0 "Have Political Authority of at least "
  YEARLY_DEVOTION:0 "Yearly Political Authority"
- DEVOTION_IRO:0 "§YDevotion§!\nPolitical Authority changes by $CHANGE$ every year due to:\n$WHY$"
+ DEVOTION_IRO:0 "§YPolitical Authority§!\nPolitical Authority changes by $CHANGE$ every year due to:\n$WHY$"
  YOU_DEVOTION_DRO:0 "This represents the assertiveness inside our country. The higher it is, the more efficient our oligarchy will run!\nThis level of Political Authority gives the following effects:"
  THEY_DEVOTION_DRO:0 "This represents the assertiveness inside their country. The higher it is, the more efficient their oligarchy will run!\nThis level of Political Authority gives the following effects:"
  PATRIARCH_AUTHORITY_LESS_THAN:0 "Religious Authority is less than §Y$VAL$§W percent.\n"


### PR DESCRIPTION
Fixes #262.

The "Devotion" government mechanic is repurposed in IU as **Political Authority**, and nearly all `DEVOTION_*` strings were already renamed. One leak remained: the `DEVOTION_IRO` tooltip **header** still read `§YDevotion§!` while its own body.

I got it fixed and verified it in-game:

<img width="848" height="716" alt="Screenshot 2026-06-28 at 1 19 13 AM" src="https://github.com/user-attachments/assets/90a509fe-10fd-4ff7-8517-d8bcfb548bc4" />

Change: one line in `localisation/replace/replace_EU4_l_english.yml`