### PR TITLE
Fix Diplomatic Reputation AI-acceptance tooltip (#355)

### DIFF
--- a/common/new_diplomatic_actions/ask_government_advice.txt
+++ b/common/new_diplomatic_actions/ask_government_advice.txt
@@ -78,7 +78,7 @@ ask_government_advice_ally = {
 		}
 
 		add_entry = {
-			name = DIPLOMATIC_REPUTATION
+			name = DIPLOMATIC_REPUTATION_LABEL
 			export_to_variable = {
 				variable_name = ai_value
 				value = modifier:diplomatic_reputation
@@ -261,7 +261,7 @@ ask_government_advice_overlord = {
 		}
 
 		add_entry = {
-			name = DIPLOMATIC_REPUTATION
+			name = DIPLOMATIC_REPUTATION_LABEL
 			export_to_variable = {
 				variable_name = ai_value
 				value = modifier:diplomatic_reputation

--- a/common/new_diplomatic_actions/phoenician_colonies_interactions.txt
+++ b/common/new_diplomatic_actions/phoenician_colonies_interactions.txt
@@ -118,7 +118,7 @@ establish_phoenician_colony = {
 			divide_variable = { which = ai_value value = 8 }
 		}
 		add_entry = {
-			name = DIPLOMATIC_REPUTATION
+			name = DIPLOMATIC_REPUTATION_LABEL
 			export_to_variable = {
 				variable_name = ai_value
 				value = modifier:diplomatic_reputation

--- a/common/new_diplomatic_actions/socii_interactions.txt
+++ b/common/new_diplomatic_actions/socii_interactions.txt
@@ -108,7 +108,7 @@ ask_for_socii_subject = {
 			divide_variable = { which = ai_value value = 10 }
 		}
 		add_entry = {
-			name = DIPLOMATIC_REPUTATION
+			name = DIPLOMATIC_REPUTATION_LABEL
 			export_to_variable = {
 				variable_name = ai_value
 				value = modifier:diplomatic_reputation

--- a/common/new_diplomatic_actions/sukkal_interactions.txt
+++ b/common/new_diplomatic_actions/sukkal_interactions.txt
@@ -118,7 +118,7 @@ reconciliate_sukkal = {
 			divide_variable = { which = ai_value value = 10 }
 		}
 		add_entry = {
-			name = DIPLOMATIC_REPUTATION
+			name = DIPLOMATIC_REPUTATION_LABEL
 			export_to_variable = {
 				variable_name = ai_value
 				value = modifier:diplomatic_reputation

--- a/common/new_diplomatic_actions/velir_interactions.txt
+++ b/common/new_diplomatic_actions/velir_interactions.txt
@@ -106,7 +106,7 @@ establish_velir_diplomatic = {
 			divide_variable = { which = ai_value value = 8 }
 		}
 		add_entry = {
-			name = DIPLOMATIC_REPUTATION
+			name = DIPLOMATIC_REPUTATION_LABEL
 			export_to_variable = {
 				variable_name = ai_value
 				value = modifier:diplomatic_reputation

--- a/localisation/subject_type_l_english.yml
+++ b/localisation/subject_type_l_english.yml
@@ -182,7 +182,7 @@
  DIFFERENT_PRIMARY_CULTURE:0 "Different Primary Culture"
  BASE_VALUE_CUSTOM:0 "Base Value"
  TOTAL_DEVELOPMENT:0 "Population"
- DIPLOMATIC_REPUTATION:0 "Diplomatic Reputation"
+ DIPLOMATIC_REPUTATION_LABEL:0 "Diplomatic Reputation"
  TRUST:0 "Trust"
  BORDER_DISTANCE:0 "Border Distance"
  OPINION:0 "Opinion"


### PR DESCRIPTION
Closes #355.

The "Diplomatic Reputation" entry in the AI-acceptance breakdown of several Influence diplomatic actions showed the long diplo-rep stat description instead of the short vanilla label.

The loc key `DIPLOMATIC_REPUTATION` was defined twice:
- `localisation/subject_type_l_english.yml` -> `"Diplomatic Reputation"` (the intended label)
- `localisation/replace/replace_diplomacy_l_english.yml` -> the long stat description

Gave the AI-acceptance label its own key `DIPLOMATIC_REPUTATION_LABEL`, leaving the vanilla stat description untouched.

The same key was shared by 6 `add_entry` references, so all are updated: Ask for Socii, Phoenician colony, Velir, Sukkal, and Ask Government Advice (×2).