### PR TITLE
Fix Pantikapaion 'Protect the colonies' mission scope errors (#321)

### DIFF
--- a/missions/pantikapaion_missions.txt
+++ b/missions/pantikapaion_missions.txt
@@ -1611,13 +1611,15 @@ panti_mis_slot_five = {
 				}
 
 				AND = {
-					OR = {
-						alliance_with = PHA
-						guaranteed_by = ROOT
-					}
-					has_opinion = {
-						who = ROOT
-						value = 100
+					PHA = {
+						OR = {
+							alliance_with = ROOT
+							guaranteed_by = ROOT
+						}
+						has_opinion = {
+							who = ROOT
+							value = 100
+						}
 					}
 					army_strength = {
 						who = PHA
@@ -1634,13 +1636,15 @@ panti_mis_slot_five = {
 				}
 
 				AND = {
-					OR = {
-						alliance_with = TRA
-						guaranteed_by = ROOT
-					}
-					has_opinion = {
-						who = ROOT
-						value = 100
+					TRA = {
+						OR = {
+							alliance_with = ROOT
+							guaranteed_by = ROOT
+						}
+						has_opinion = {
+							who = ROOT
+							value = 100
+						}
 					}
 					army_strength = {
 						who = TRA
@@ -1656,13 +1660,15 @@ panti_mis_slot_five = {
 				}
 
 				AND = {
-					OR = {
-						alliance_with = KTR
-						guaranteed_by = ROOT
-					}
-					has_opinion = {
-						who = ROOT
-						value = 100
+					KTR = {
+						OR = {
+							alliance_with = ROOT
+							guaranteed_by = ROOT
+						}
+						has_opinion = {
+							who = ROOT
+							value = 100
+						}
 					}
 					army_strength = {
 						who = KTR
@@ -1678,13 +1684,15 @@ panti_mis_slot_five = {
 				}
 
 				AND = {
-					OR = {
-						alliance_with = AMX
-						guaranteed_by = ROOT
-					}
-					has_opinion = {
-						who = ROOT
-						value = 100
+					AMX = {
+						OR = {
+							alliance_with = ROOT
+							guaranteed_by = ROOT
+						}
+						has_opinion = {
+							who = ROOT
+							value = 100
+						}
 					}
 					army_strength = {
 						who = AMX


### PR DESCRIPTION
Closes #321.

The PHA, TRA, KTR and AMX branches of `panti_safeguard_colonies` ("Protect the colonies") were missing the minor's tag scope around their alliance/guarantee and opinion conditions, so they evaluated in ROOT scope:

- `guaranteed_by = ROOT` read as "ROOT is guaranteed by ROOT"
- `has_opinion = { who = ROOT value = 100 }` read as "ROOT has opinion of ROOT >= 100"

These are nonsense/always-true conditions rather than the intended "the minor is allied with or guaranteed by ROOT and has opinion of ROOT >= 100". The working SNP branch already wraps its conditions in `SNP = { ... }`; this change mirrors that for the other four minors. It also fixes the misleading tooltip indentation the issue reported, since the tooltip nesting follows the script nesting.